### PR TITLE
Add `:required` for `:flags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Added `:required` for `:flags`
+
 ## Fixed
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ If you are explicit about which flags you accept, then you may prefer not to let
 you can set `:strict? true`. In this mode only explicitly configured flags are
 accepted, others throw an error.
 
-A final possibility is to set `:middleware` for a flag, this is a function or
+Another possibility is to set `:middleware` for a flag, this is a function or
 list of functions that get wrapped around the final command.
 
 ```clj
@@ -255,6 +255,18 @@ list of functions that get wrapped around the final command.
                           (fn [opts]
                             (binding [*format* :long]
                               (cmd opts))))]}]}]})
+```
+
+Finally, it's possible to set `:required`, to indicate for users that a flag
+must always be passed:
+
+```clj
+(cli/dispatch
+ {:command #'cli-test
+  :flags ["-v, --verbose" "Increases verbosity"
+          "--input FILE" "Specify the input file"
+          "--env=<dev|prod|staging>" {:doc "Select an environment"
+                                      :required true}] })
 ```
 
 ### Commands

--- a/src/lambdaisland/cli.clj
+++ b/src/lambdaisland/cli.clj
@@ -413,6 +413,7 @@
     take an argument.
   - `:middleware` Function or sequence of functions that will wrap the command
     function if this flag is present.
+  - `:required` Boolean value to indicate if the flag is required.
 
   This docstring is just a summary, see the `com.lambdaisland/cli` README for
   details.


### PR DESCRIPTION
Solves https://github.com/lambdaisland/cli/issues/4

### Notes
- Make `(parse-error!)` thrown an Exception rather than calling `(System/exit)`, so tests can be executed and checked against it
- Split the main `dispatch` function into `(dispatch*)` and `(dispatch)`: the former contains the actual logic and the latter handles exceptions
- Fixes a small duplicated blank space when printing `Unknown flag:`
- In case of an Exception is caught, make `(dispatch)` print `FATAL` messages to `stderr`
- Add tests